### PR TITLE
fix: tests compilation error and race

### DIFF
--- a/Tests/NMAImageFetchTests/NMAImageFetchTests.swift
+++ b/Tests/NMAImageFetchTests/NMAImageFetchTests.swift
@@ -3,6 +3,7 @@ import NMAImageFetch
 import NMAImageFetchSwift
 import UIKit
 
+@available(iOS 13, *)
 final class NMAImageFetchTests: XCTestCase {
 
     override func setUp() async throws {

--- a/Tests/NMAImageFetchTests/NMAImageFetchTests.swift
+++ b/Tests/NMAImageFetchTests/NMAImageFetchTests.swift
@@ -25,6 +25,7 @@ final class NMAImageFetchTests: XCTestCase {
                 XCTFail()
             }
         }
+        wait(for: [expectationWithoutCaching], timeout: 5)
         let expectationWithCaching = expectation(description: "Image request finished width caching")
         _ = imageFetch.requestImage(imageFetchRequest) { result in
             expectationWithCaching.fulfill()
@@ -35,7 +36,7 @@ final class NMAImageFetchTests: XCTestCase {
                 XCTFail()
             }
         }
-        waitForExpectations(timeout: 5)
+        wait(for: [expectationWithCaching], timeout: 5)
     }
 
     func testVectorLoading() throws {
@@ -54,6 +55,7 @@ final class NMAImageFetchTests: XCTestCase {
                 XCTFail()
             }
         }
+        wait(for: [expectationWithoutCaching], timeout: 5)
         let expectationWithCaching = expectation(description: "Image request finished with caching")
         _ = imageFetch.requestImage(imageFetchRequest) { result in
             expectationWithCaching.fulfill()
@@ -64,7 +66,7 @@ final class NMAImageFetchTests: XCTestCase {
                 XCTFail()
             }
         }
-        waitForExpectations(timeout: 5)
+        wait(for: [expectationWithCaching], timeout: 5)
     }
 
     func testCancel() {


### PR DESCRIPTION
* Make tests compile by adding `available(iOS 13)`. In this way we can leave the package deployment target at iOS 12.
 
* Remove fetch test race by awaiting the expectations in order
   - Prevents the fetch and fetch-from-cache test steps to execute concurrently. Likely it wasn't the original test authors intention to execute those concurrently.
   - At this point there's no attempt to fix the underlying bug of two fetch results overwriting each other. That's something that should eventually be fixed at the requests queue level.
   
Resolves #24