### PR TITLE
fix: add `trustAllServerCertificates` property to `ImageFetch`

### DIFF
--- a/Sources/Objc/NImageFetch.m
+++ b/Sources/Objc/NImageFetch.m
@@ -87,19 +87,18 @@
     return self;
 }
 
-#if defined(DEBUG) || defined(NOMATESTFLIGHT)
-
-/* In DEBUG mode, blindly trust any server certificate */
-
 - (void)URLSession:(NSURLSession *)session
 didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
-    NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
-    completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+    if (self.trustAllServerCertificates) {
+        completionHandler(NSURLSessionAuthChallengeUseCredential,
+                          [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling,
+                          nil);
+    }
 }
-
-#endif
 
 - (void)deactivateMemoryCache
 {

--- a/Sources/Objc/Public/NImageFetch.h
+++ b/Sources/Objc/Public/NImageFetch.h
@@ -62,6 +62,9 @@ NS_SWIFT_NAME(ImageFetch)
 
 @property (nonatomic, class, readonly) NImageFetch *sharedImageFetch;
 
+/// Whether to blindly trust all server certificates.
+@property (nonatomic) BOOL trustAllServerCertificates;
+
 /** Start fetching the image specified by the URL request.
  *  @param request Request to fetch
  *  @return An NImageFetchTask, or nil if the image did need to be fetched (already in cache).


### PR DESCRIPTION
Instead of checking the preprocessor macros to decide whether all server certificates should be trusted, this is now done through a new property in `ImageFetch`, `trustAllServerCertificates`, which the clients can freely set.