### PR TITLE
feat: Add placeholder support for NImageFetchView

### DIFF
--- a/Sources/Objc/NImageFetchView.m
+++ b/Sources/Objc/NImageFetchView.m
@@ -76,6 +76,7 @@
 {
     if(image == nil) {
         self.status = NImageFetchViewStatusNotLoaded;
+        [self _hidePlaceholderAnimated:NO];
         self.request = nil;
     }
     [super setImage:image];
@@ -128,7 +129,7 @@
                                      if (strongSelf.placeholderView.superview) {
                                          // With placeholder: suppress native fade-in, just fade out placeholder
                                          [strongSelf _hidePlaceholderAnimated:((flags & NImageFetchFlagSync) == 0)];
-                                     } else if(strongSelf.superview && !weakSelf.hidden &&
+                                     } else if(strongSelf.superview && !strongSelf.hidden &&
                                         ((animated == NImageFetchViewAnimatedAlways) ||
                                         ((animated == NImageFetchViewAnimatedIfAsync) &&
                                          ((flags & NImageFetchFlagSync) == 0)))) {
@@ -182,6 +183,7 @@
         [imageFetch cancel:self.imageFetchTask];
         self.imageFetchTask = nil;
         self.status = NImageFetchViewStatusNotLoaded;
+        [self _hidePlaceholderAnimated:NO];
     }
 }
 

--- a/Sources/Objc/NImageFetchView.m
+++ b/Sources/Objc/NImageFetchView.m
@@ -14,6 +14,56 @@
 @implementation NImageFetchView
 
 
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        _placeholderFadeOutDuration = 0.3;
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        _placeholderFadeOutDuration = 0.3;
+    }
+    return self;
+}
+
+- (void)_showPlaceholderIfNeeded {
+    if (!self.placeholderView) return;
+    if (self.placeholderView.superview == self) return;
+    self.placeholderView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.placeholderView.alpha = 1.0;
+    [self addSubview:self.placeholderView];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.placeholderView.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [self.placeholderView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [self.placeholderView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [self.placeholderView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor]
+    ]];
+}
+
+- (void)_hidePlaceholderAnimated:(BOOL)animated {
+    UIView *placeholder = self.placeholderView;
+    if (!placeholder || !placeholder.superview) return;
+    
+    if (!animated) {
+        [placeholder removeFromSuperview];
+        return;
+    }
+    
+    [UIView animateWithDuration:self.placeholderFadeOutDuration
+                          delay:0
+                        options:UIViewAnimationOptionCurveEaseOut
+                     animations:^{
+        placeholder.alpha = 0.0;
+    } completion:^(BOOL finished) {
+        [placeholder removeFromSuperview];
+        placeholder.alpha = 1.0; // Reset for reuse
+    }];
+}
+
 - (void)dealloc
 {
     /* Do not notify delegate while deallocating */
@@ -48,6 +98,9 @@
      loading after the new one, and override it */
     [self cancelLoading];
 
+    [self _hidePlaceholderAnimated:NO]; // Clean previous placeholder
+    [self _showPlaceholderIfNeeded];
+
     /* Save the urlRequest in order to make possible to retry the load */
     self.request = request;
 
@@ -62,6 +115,7 @@
                                          strongSelf.image = fallbackImage;
                                      }
                                      strongSelf.status = NImageFetchViewStatusNotLoaded;
+                                     [strongSelf _hidePlaceholderAnimated:NO];
                                      [strongSelf hideActivityIndicator];
                                      if (completion != nil) {
                                          completion(error);
@@ -70,7 +124,10 @@
                                      [strongSelf hideActivityIndicator];
                                      [strongSelf setImage:image];
                                      strongSelf.status = NImageFetchViewStatusLoaded;
-                                     if(strongSelf.superview && !weakSelf.hidden &&
+                                     if (strongSelf.placeholderView.superview) {
+                                         // With placeholder: suppress native fade-in, just fade out placeholder
+                                         [strongSelf _hidePlaceholderAnimated:((flags & NImageFetchFlagSync) == 0)];
+                                     } else if(strongSelf.superview && !weakSelf.hidden &&
                                         ((animated == NImageFetchViewAnimatedAlways) ||
                                         ((animated == NImageFetchViewAnimatedIfAsync) &&
                                          ((flags & NImageFetchFlagSync) == 0)))) {
@@ -95,6 +152,7 @@
         self.status = NImageFetchViewStatusLoading;
     } else {
         self.status = NImageFetchViewStatusLoaded;
+        [self _hidePlaceholderAnimated:NO]; // Sync cache hit
     }
     self.imageFetchTask = anImageFetchTask;
 }

--- a/Sources/Objc/NImageFetchView.m
+++ b/Sources/Objc/NImageFetchView.m
@@ -35,6 +35,7 @@
     if (self.placeholderView.superview == self) return;
     self.placeholderView.translatesAutoresizingMaskIntoConstraints = NO;
     self.placeholderView.alpha = 1.0;
+    self.placeholderView.userInteractionEnabled = NO;
     [self addSubview:self.placeholderView];
     [NSLayoutConstraint activateConstraints:@[
         [self.placeholderView.topAnchor constraintEqualToAnchor:self.topAnchor],

--- a/Sources/Objc/Public/NImageFetchView.h
+++ b/Sources/Objc/Public/NImageFetchView.h
@@ -30,6 +30,14 @@ typedef void (^NImageFetchViewCompletion)(NSError * _Nullable);
 
 @property (readonly, nonatomic) NImageFetchViewStatus status;
 
+/// View displayed as a placeholder during image loading.
+/// Assign before calling setImage. If nil (default), no placeholder is shown.
+@property (nonatomic, strong, nullable) UIView *placeholderView;
+
+/// Duration of the placeholder fade-out animation when image loads. Default: 0.3s.
+@property (nonatomic, assign) NSTimeInterval placeholderFadeOutDuration;
+
+
 /** Asynchronously downloads the image given by the specified NImageFetchRequest and sets it to the image view.
  @param request NImageFetchRequest to fetch
  @param animated Specifies whether to fade in the image with an animation.

--- a/Sources/Swift/ImageFetchView.swift
+++ b/Sources/Swift/ImageFetchView.swift
@@ -15,37 +15,44 @@ public struct ImageFetchView: UIViewRepresentable {
     private let animated: NImageFetchViewAnimated
     private let fallbackImage: UIImage?
     private let completion: NImageFetchViewCompletion?
-    
+    private let placeholderProvider: ImageFetchPlaceholderProvider?
+
     public init(url: URL,
                 animated: NImageFetchViewAnimated = .ifAsync,
                 fallbackImage: UIImage? = nil,
+                placeholderProvider: ImageFetchPlaceholderProvider? = nil,
                 completion: NImageFetchViewCompletion? = nil) {
-        self.init(urlRequest: URLRequest(url: url), animated: animated, fallbackImage: fallbackImage)
+        self.init(urlRequest: URLRequest(url: url), animated: animated, fallbackImage: fallbackImage, placeholderProvider: placeholderProvider, completion: completion)
     }
-    
+
     public init(urlRequest: URLRequest,
                 animated: NImageFetchViewAnimated = .ifAsync,
                 fallbackImage: UIImage? = nil,
+                placeholderProvider: ImageFetchPlaceholderProvider? = nil,
                 completion: NImageFetchViewCompletion? = nil) {
-        self.init(imageFetchRequest: ImageFetchRequest(urlRequest: urlRequest), animated: animated, fallbackImage: fallbackImage)
+        self.init(imageFetchRequest: ImageFetchRequest(urlRequest: urlRequest), animated: animated, fallbackImage: fallbackImage, placeholderProvider: placeholderProvider, completion: completion)
     }
-    
+
     public init(imageFetchRequest: ImageFetchRequest,
                 animated: NImageFetchViewAnimated = .ifAsync,
                 fallbackImage: UIImage? = nil,
+                placeholderProvider: ImageFetchPlaceholderProvider? = nil,
                 completion: NImageFetchViewCompletion? = nil) {
         self.imageFetchRequest = imageFetchRequest
         self.animated = animated
         self.fallbackImage = fallbackImage
+        self.placeholderProvider = placeholderProvider
         self.completion = completion
     }
-    
+
     public func makeUIView(context: Context) -> NImageFetchView {
         let imageView: NImageFetchView = .init(frame: .zero)
+        if let provider = placeholderProvider {
+            imageView.configurePlaceholder(provider: provider)
+        }
         imageView.setImage(imageFetchRequest, animated: animated, fallbackImage: fallbackImage, completion: completion)
         return imageView
     }
-    
+
     public func updateUIView(_ uiView: NImageFetchView, context: Context) {}
 }
-

--- a/Sources/Swift/Skeleton/ImageFetchPlaceholderProvider.swift
+++ b/Sources/Swift/Skeleton/ImageFetchPlaceholderProvider.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Protocol for providing placeholder views during image loading.
 /// Implement to create custom placeholders (shimmer, blur, solid color, etc.)
 public protocol ImageFetchPlaceholderProvider {
-    /// Creates a new placeholder view instance.
-    /// Called once per image load.
+    /// Creates a placeholder view instance.
+    /// Called once when configuring the placeholder; the view is reused across loads.
     func makePlaceholderView() -> UIView
 }

--- a/Sources/Swift/Skeleton/ImageFetchPlaceholderProvider.swift
+++ b/Sources/Swift/Skeleton/ImageFetchPlaceholderProvider.swift
@@ -1,0 +1,11 @@
+//  Copyright © 2026 Nomasystems. All rights reserved.
+
+import UIKit
+
+/// Protocol for providing placeholder views during image loading.
+/// Implement to create custom placeholders (shimmer, blur, solid color, etc.)
+public protocol ImageFetchPlaceholderProvider {
+    /// Creates a new placeholder view instance.
+    /// Called once per image load.
+    func makePlaceholderView() -> UIView
+}

--- a/Sources/Swift/Skeleton/ImageFetchPlaceholderProvider.swift
+++ b/Sources/Swift/Skeleton/ImageFetchPlaceholderProvider.swift
@@ -7,5 +7,5 @@ import UIKit
 public protocol ImageFetchPlaceholderProvider {
     /// Creates a placeholder view instance.
     /// Called once when configuring the placeholder; the view is reused across loads.
-    func makePlaceholderView() -> UIView
+    @MainActor func makePlaceholderView() -> UIView
 }

--- a/Sources/Swift/Skeleton/NImageFetchView+Skeleton.swift
+++ b/Sources/Swift/Skeleton/NImageFetchView+Skeleton.swift
@@ -1,0 +1,36 @@
+//  Copyright © 2026 Nomasystems. All rights reserved.
+
+import UIKit
+import NMAImageFetch
+
+extension NImageFetchView {
+
+    /// Configures the placeholder using a provider conforming to ImageFetchPlaceholderProvider.
+    /// Must be called BEFORE setImage.
+    public func configurePlaceholder(provider: ImageFetchPlaceholderProvider) {
+        self.placeholderView = provider.makePlaceholderView()
+    }
+
+    /// Configures the placeholder with the built-in shimmer.
+    /// Must be called BEFORE setImage.
+    public func enableShimmerPlaceholder(
+        baseColor: UIColor = ShimmerPlaceholderView.defaultBaseColor,
+        shimmerColor: UIColor = ShimmerPlaceholderView.defaultShimmerColor,
+        animationDuration: TimeInterval = 1.5,
+        fadeOutDuration: TimeInterval = 0.3
+    ) {
+        let shimmer = ShimmerPlaceholderView(
+            baseColor: baseColor,
+            shimmerColor: shimmerColor,
+            animationDuration: animationDuration
+        )
+        self.placeholderView = shimmer
+        self.placeholderFadeOutDuration = fadeOutDuration
+    }
+
+    /// Removes and disables the placeholder for this instance.
+    public func disablePlaceholder() {
+        self.placeholderView?.removeFromSuperview()
+        self.placeholderView = nil
+    }
+}

--- a/Sources/Swift/Skeleton/ShimmerPlaceholderView.swift
+++ b/Sources/Swift/Skeleton/ShimmerPlaceholderView.swift
@@ -1,0 +1,91 @@
+//  Copyright © 2026 Nomasystems. All rights reserved.
+
+import UIKit
+
+/// A view with a shimmer (horizontal gradient sweep) animation.
+/// Used as the default placeholder if no custom one is provided.
+public final class ShimmerPlaceholderView: UIView {
+
+    public static let defaultBaseColor: UIColor = {
+        if #available(iOS 13.0, *) { return .systemGray5 }
+        return UIColor(red: 0.90, green: 0.90, blue: 0.92, alpha: 1.0)
+    }()
+
+    public static let defaultShimmerColor: UIColor = {
+        if #available(iOS 13.0, *) { return .systemGray6 }
+        return UIColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1.0)
+    }()
+
+    private let gradientLayer = CAGradientLayer()
+
+    public var baseColor: UIColor {
+        didSet { updateColors() }
+    }
+
+    public var shimmerColor: UIColor {
+        didSet { updateColors() }
+    }
+
+    public var animationDuration: TimeInterval
+
+    public init(baseColor: UIColor = ShimmerPlaceholderView.defaultBaseColor,
+                shimmerColor: UIColor = ShimmerPlaceholderView.defaultShimmerColor,
+                animationDuration: TimeInterval = 1.5) {
+        self.baseColor = baseColor
+        self.shimmerColor = shimmerColor
+        self.animationDuration = animationDuration
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        backgroundColor = baseColor
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        updateColors()
+        layer.addSublayer(gradientLayer)
+    }
+
+    private func updateColors() {
+        gradientLayer.colors = [
+            baseColor.cgColor,
+            shimmerColor.cgColor,
+            baseColor.cgColor
+        ]
+        gradientLayer.locations = [0.0, 0.5, 1.0]
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
+    }
+
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            startAnimating()
+        } else {
+            stopAnimating()
+        }
+    }
+
+    private func startAnimating() {
+        guard gradientLayer.animation(forKey: "shimmer") == nil else { return }
+        let animation = CABasicAnimation(keyPath: "locations")
+        animation.fromValue = [-1.0, -0.5, 0.0]
+        animation.toValue = [1.0, 1.5, 2.0]
+        animation.duration = animationDuration
+        animation.repeatCount = .infinity
+        animation.isRemovedOnCompletion = false
+        gradientLayer.add(animation, forKey: "shimmer")
+    }
+
+    private func stopAnimating() {
+        gradientLayer.removeAnimation(forKey: "shimmer")
+    }
+}

--- a/Tests/NMAImageFetchTests/NImageFetchViewSkeletonTests.swift
+++ b/Tests/NMAImageFetchTests/NImageFetchViewSkeletonTests.swift
@@ -1,0 +1,122 @@
+//  Copyright © 2026 Nomasystems. All rights reserved.
+
+import Testing
+import UIKit
+@testable import NMAImageFetch
+@testable import NMAImageFetchSwift
+
+@MainActor @Suite("NImageFetchView Skeleton")
+struct NImageFetchViewSkeletonTests {
+
+    @Test("placeholderFadeOutDuration defaults to 0.3")
+    func test_fadeOutDuration_defaultValue() {
+        let sut = NImageFetchView(frame: .zero)
+        #expect(sut.placeholderFadeOutDuration == 0.3)
+    }
+
+    @Test("placeholderView is nil by default")
+    func test_placeholderView_nilByDefault() {
+        let sut = NImageFetchView(frame: .zero)
+        #expect(sut.placeholderView == nil)
+    }
+
+    @Test("Placeholder is added as subview when showPlaceholderIfNeeded is triggered via setImage")
+    func test_placeholder_addedAsSubview_whenSetImageCalled() {
+        let sut = NImageFetchView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let placeholder = UIView()
+        sut.placeholderView = placeholder
+
+        // Trigger setImage with an invalid request to see placeholder added
+        let request = ImageFetchRequest(urlRequest: URLRequest(url: URL(string: "https://invalid.test/image.png")!))
+        sut.setImage(request, animated: .never)
+
+        #expect(placeholder.superview === sut)
+    }
+
+    @Test("Placeholder is NOT added when placeholderView is nil")
+    func test_placeholder_notAdded_whenNil() {
+        let sut = NImageFetchView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        // placeholderView is nil by default
+
+        let request = ImageFetchRequest(urlRequest: URLRequest(url: URL(string: "https://invalid.test/image.png")!))
+        sut.setImage(request, animated: .never)
+
+        #expect(sut.subviews.isEmpty || sut.subviews.allSatisfy { $0 !== sut.placeholderView })
+    }
+
+    @Test("enableShimmerPlaceholder sets placeholderView to ShimmerPlaceholderView")
+    func test_enableShimmer_setsPlaceholder() {
+        let sut = NImageFetchView(frame: .zero)
+        sut.enableShimmerPlaceholder()
+        #expect(sut.placeholderView is ShimmerPlaceholderView)
+    }
+
+    @Test("enableShimmerPlaceholder sets custom fadeOutDuration")
+    func test_enableShimmer_setsFadeOutDuration() {
+        let sut = NImageFetchView(frame: .zero)
+        sut.enableShimmerPlaceholder(fadeOutDuration: 0.5)
+        #expect(sut.placeholderFadeOutDuration == 0.5)
+    }
+
+    @Test("disablePlaceholder removes and nils placeholderView")
+    func test_disablePlaceholder_removesView() {
+        let sut = NImageFetchView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let placeholder = UIView()
+        sut.placeholderView = placeholder
+        sut.addSubview(placeholder)
+
+        sut.disablePlaceholder()
+
+        #expect(sut.placeholderView == nil)
+        #expect(placeholder.superview == nil)
+    }
+
+    @Test("configurePlaceholder uses provider to create view")
+    func test_configurePlaceholder_usesProvider() {
+        struct MockProvider: ImageFetchPlaceholderProvider {
+            func makePlaceholderView() -> UIView {
+                let view = UIView()
+                view.tag = 999
+                return view
+            }
+        }
+        let sut = NImageFetchView(frame: .zero)
+        sut.configurePlaceholder(provider: MockProvider())
+        #expect(sut.placeholderView?.tag == 999)
+    }
+
+    @Test("ShimmerPlaceholderView starts animating when added to window")
+    func test_shimmer_animatesWhenInWindow() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let shimmer = ShimmerPlaceholderView()
+        shimmer.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        window.addSubview(shimmer)
+        window.makeKeyAndVisible()
+
+        // Give run loop a cycle
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+        let gradientLayer = shimmer.layer.sublayers?.first as? CAGradientLayer
+        #expect(gradientLayer?.animation(forKey: "shimmer") != nil)
+    }
+
+    @Test("Repeated setImage cleans previous placeholder")
+    func test_repeatedSetImage_cleansPreviousPlaceholder() {
+        let sut = NImageFetchView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let placeholder = UIView()
+        sut.placeholderView = placeholder
+
+        let request = ImageFetchRequest(urlRequest: URLRequest(url: URL(string: "https://invalid.test/1.png")!))
+        sut.setImage(request, animated: .never)
+        #expect(placeholder.superview === sut)
+
+        // Second call should still have placeholder (cleaned and re-shown)
+        let request2 = ImageFetchRequest(urlRequest: URLRequest(url: URL(string: "https://invalid.test/2.png")!))
+        sut.setImage(request2, animated: .never)
+        #expect(placeholder.superview === sut)
+
+        // Only one instance of placeholder in subviews
+        let placeholderCount = sut.subviews.filter { $0 === placeholder }.count
+        #expect(placeholderCount == 1)
+    }
+}


### PR DESCRIPTION
# More info at [OYSHOIOS-10812](https://jira.inditex.com/jira/browse/OYSHOIOS-10812)

## Public API Changes (ObjC)

### NImageFetchView.h — 2 new properties

| Property | Description |
|----------|-------------|
| `@property UIView *placeholderView` | View displayed as a placeholder during image loading. Assign **before** calling `setImage`. If `nil` (default), no placeholder is shown. |
| `@property NSTimeInterval placeholderFadeOutDuration` | Duration of the placeholder fade-out animation when the image loads. Default: `0.3s`. |

### NImageFetchView.m — Placeholder lifecycle (+60 lines)

| Method | Description |
|--------|-------------|
| `initWithFrame:` / `initWithCoder:` | Initialize `_placeholderFadeOutDuration = 0.3` |
| `_showPlaceholderIfNeeded` | Adds `placeholderView` as a subview with **Auto Layout constraints** (top/leading/trailing/bottom). Idempotent — won't duplicate if already added. |
| `_hidePlaceholderAnimated:` | Animated fade-out or immediate removal. Resets alpha to 1.0 after completion for reuse. |

**Integration into the loading flow:**

- **Before loading:** Cleans previous placeholder + shows new one (`setImageFromRequest:animated:fallbackImage:completion:`)
- **Error:** Hides placeholder without animation
- **Success (async):** Suppresses the native image view fade-in; uses placeholder fade-out instead
- **Success (sync/cache hit):** Hides placeholder without animation

---

## New Swift Module: `Sources/Swift/Skeleton/`

### ImageFetchPlaceholderProvider.swift — Protocol

```swift
public protocol ImageFetchPlaceholderProvider {
    func makePlaceholderView() -> UIView
}
```

Allows injecting any type of placeholder (shimmer, blur, solid color, etc.) without coupling to the framework.

### NImageFetchView+Skeleton.swift — Swift API Extension

| Method | Description |
|--------|-------------|
| `configurePlaceholder(provider:)` | Configures placeholder via protocol |
| `enableShimmerPlaceholder(baseColor:shimmerColor:animationDuration:fadeOutDuration:)` | Enables built-in shimmer with customizable values |
| `disablePlaceholder()` | Removes and nullifies the placeholder |

### ShimmerPlaceholderView.swift — Shimmer implementation (91 lines)

- Horizontal `CAGradientLayer` with infinite `locations` animation loop
- Default colors with iOS 12 support (`if #available(iOS 13.0, *)` for `systemGray5`/`systemGray6`)
- Auto-start/stop in `didMoveToWindow()` (does not animate off-screen)
- Public properties: `baseColor`, `shimmerColor`, `animationDuration`

---

## Modified Existing File

### ImageFetchView.swift — SwiftUI Wrapper

- Added `placeholderProvider: ImageFetchPlaceholderProvider?` parameter to all 3 initializers
- In `makeUIView`, if provider exists, calls `configurePlaceholder(provider:)` before `setImage`

---

## Tests

### NImageFetchViewSkeletonTests.swift — 10 tests (Swift Testing)

| Test | Validates |
|------|-----------|
| `test_fadeOutDuration_defaultValue` | Default = 0.3 |
| `test_placeholderView_nilByDefault` | No placeholder by default |
| `test_placeholder_addedAsSubview_whenSetImageCalled` | Added when setImage is called |
| `test_placeholder_notAdded_whenNil` | Not added if nil |
| `test_enableShimmer_setsPlaceholder` | Correct type |
| `test_enableShimmer_setsFadeOutDuration` | Custom duration |
| `test_disablePlaceholder_removesView` | Full cleanup |
| `test_configurePlaceholder_usesProvider` | Protocol works |
| `test_shimmer_animatesWhenInWindow` | Animation active in window |
| `test_repeatedSetImage_cleansPreviousPlaceholder` | No duplicate subviews |

<img width="450" alt="NMAlmaceFetch" src="https://github.com/user-attachments/assets/fdbc761b-643c-45fa-9bc1-40bea7245a24" />

### Video

https://github.com/user-attachments/assets/6207c0e3-c389-49c4-95c6-35da6417e53d

You can easily test it using this preview while using the **Network Link Conditioner**:
```swift
import SwiftUI
import NMAImageFetch

/// Preview to test the default shimmer skeleton behavior.
@available(iOS 14.0, *)
struct SkeletonPreview: PreviewProvider {
    static var previews: some View {
        VStack(spacing: 20) {
            ImageFetchView(
                url: URL(string: "https://picsum.photos/1500")!,
                placeholderProvider: ShimmerPlaceholderProvider()
            )
            .frame(width: 200, height: 300)
            .clipShape(RoundedRectangle(cornerRadius: 12))

            ImageFetchView(
                url: URL(string: "https://picsum.photos/1501")!,
                placeholderProvider: ShimmerPlaceholderProvider()
            )
            .frame(width: 300, height: 250)
            .clipShape(RoundedRectangle(cornerRadius: 8))

        }
        .padding()
    }
}

/// Simple provider that creates a ShimmerPlaceholderView with default configuration.
private struct ShimmerPlaceholderProvider: ImageFetchPlaceholderProvider {
    func makePlaceholderView() -> UIView {
        ShimmerPlaceholderView()
    }
}
```